### PR TITLE
Fix issue in test: Added optimization level -O1 during clang compilat…

### DIFF
--- a/test/smoke_test/float_args.c
+++ b/test/smoke_test/float_args.c
@@ -1,5 +1,5 @@
 // REQUIRES: system-linux
-// RUN: clang -o %t %s
+// RUN: clang -O1 -o %t %s
 // RUN: llvm-mctoll -d -I /usr/include/stdio.h %t
 // RUN: clang -o %t1 %t-dis.ll
 // RUN: %t1 2>&1 | FileCheck %s


### PR DESCRIPTION
…ion.

Without -O1, function get_second looks like this:
0000000000400500 <get_second>:
  400500:	55                   	push   rbp
  400501:	48 89 e5             	mov    rbp,rsp
  400504:	f2 0f 11 45 f8       	movsd  QWORD PTR [rbp-0x8],xmm0
  400509:	f2 0f 11 4d f0       	movsd  QWORD PTR [rbp-0x10],xmm1
  40050e:	f2 0f 10 45 f0       	movsd  xmm0,QWORD PTR [rbp-0x10]
  400513:	5d                   	pop    rbp
  400514:	c3                   	ret    
  400515:	66 2e 0f 1f 84 00 00 	nop    WORD PTR cs:[rax+rax*1+0x0]
  40051c:	00 00 00 
  40051f:	90                   	nop

After adding  -O1, it looks like this:
00000000004004f0 <get_second>:
  4004f0:	0f 28 c1             	movaps xmm0,xmm1
  4004f3:	c3                   	ret    
  4004f4:	66 2e 0f 1f 84 00 00 	nop    WORD PTR cs:[rax+rax*1+0x0]
  4004fb:	00 00 00 
  4004fe:	66 90                	xchg   ax,ax


This suggests that the "movaps" instruction is working as expected, however, "movsd" might be broken.